### PR TITLE
wip: Upload Docker images (somewhere) to simplify using this

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -1,0 +1,23 @@
+name: Pull Request
+
+on:
+
+  pull_request:
+    branches:
+      - main
+
+jobs:
+
+  docker_build_backend:
+    name: "Build docker image"
+    uses: "./.github/workflows/r-docker-build.yml"
+
+    with:
+      context: backend/
+
+  docker_build_frontend:
+    name: "Build docker image"
+    uses: "./.github/workflows/r-docker-build.yml"
+
+    with:
+      context: frontend/

--- a/.github/workflows/push_main.yml
+++ b/.github/workflows/push_main.yml
@@ -1,0 +1,34 @@
+name: Main Branch Deploy
+
+on:
+  push:
+    branches:
+      - main
+    tags:
+      - "*"
+
+jobs:
+
+  docker_push_backend:
+    name: "Push docker image"
+    uses: "./.github/workflows/r-docker-build-push.yml"
+
+    with:
+      repository: philipcristiano/support.rip
+      context: backend/
+
+    secrets:
+      DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
+      DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
+
+  docker_push_frontend:
+    name: "Push docker image"
+    uses: "./.github/workflows/r-docker-build-push.yml"
+
+    with:
+      repository: philipcristiano/support.rip
+      context: frontend/
+
+    secrets:
+      DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
+      DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}

--- a/.github/workflows/r-docker-build-push.yml
+++ b/.github/workflows/r-docker-build-push.yml
@@ -1,0 +1,72 @@
+name: Docker Build and Push
+
+on:
+  workflow_call:
+    inputs:
+
+      context:
+        description: "Docker context path"
+        default: .
+        type: string
+
+      timeout:
+        description: "Timeout for jobs in minutes"
+        default: 15
+        type: number
+
+      repository:
+        description: "Repository"
+        type: string
+
+
+    secrets:
+      DOCKER_USERNAME:
+        required: true
+      DOCKER_PASSWORD:
+        required: true
+
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    timeout-minutes: ${{ inputs.timeout }}
+    steps:
+    - uses: 'actions/checkout@v3'
+
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v2
+
+    - name: Docker meta
+      id: meta
+      uses: docker/metadata-action@v4
+      with:
+        # list of Docker images to use as base name for tags
+        images: |
+          ${{ inputs.repository }}
+
+        # generate Docker tags based on the following events/attributes
+        tags: |
+          type=schedule
+          type=ref,event=branch
+          type=ref,event=pr
+          type=semver,pattern={{version}}
+          type=semver,pattern={{major}}.{{minor}}
+          type=semver,pattern={{major}}
+          type=sha
+
+    - name: Login to Docker Hub
+      uses: docker/login-action@v2
+      with:
+        username: ${{ secrets.DOCKER_USERNAME }}
+        password: ${{ secrets.DOCKER_PASSWORD }}
+
+    - name: Build
+      uses: docker/build-push-action@v4
+      with:
+        context: ${{ inputs.context }}
+        cache-from: type=gha
+        cache-to: type=gha,mode=max
+
+        push: true
+        tags: ${{ steps.meta.outputs.tags }}

--- a/.github/workflows/r-docker-build.yml
+++ b/.github/workflows/r-docker-build.yml
@@ -1,0 +1,34 @@
+name: Docker Build
+
+on:
+  workflow_call:
+    inputs:
+
+      context:
+        description: "Docker context path"
+        default: .
+        type: string
+
+      timeout:
+        description: "Timeout for jobs in minutes"
+        default: 15
+        type: number
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    timeout-minutes: ${{ inputs.timeout }}
+    steps:
+    - uses: 'actions/checkout@v3'
+
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v2
+
+    - name: Build
+      uses: docker/build-push-action@v3
+      with:
+        push: false
+        context: ${{ inputs.context }}
+        cache-from: type=gha
+        cache-to: type=gha,mode=max


### PR DESCRIPTION
👋 At the moment this is an example to build/push Docker images (set currently to Docker Hub) in a potential path to simplifying folks trying this out. 

The README currently has steps to clone/change this repo to run this code locally. I think an easier path for folks getting started would be to use a published docker image so that someone could run `docker run -it -eOPENAI_API_KEY=your_key_goes_here -p [ports] support-rip` and get it going. 

If this path would be useful please let me know and I can continue trying that out! A single final image is easier than front/back-ends and I haven't had a chance to look into that. 

Otherwise maybe this is useful for PRs/`main` for building Docker to ensure things are working. 